### PR TITLE
Update plotting to work with Matplotlib 2.2+.

### DIFF
--- a/pseudopy/nonnormal.py
+++ b/pseudopy/nonnormal.py
@@ -119,7 +119,7 @@ class NonnormalMeshgrid(_Nonnormal):
     def plot(self, epsilons, **kwargs):
         contours = pyplot.contour(self.Real, self.Imag, self.Vals,
                                   levels=epsilons,
-                                  colors=pyplot.rcParams['axes.color_cycle'])
+                                  colors=['b', 'g', 'r', 'c', 'm', 'y', 'k'])
         plot_finish(contours, **kwargs)
         return contours
 

--- a/pseudopy/normal.py
+++ b/pseudopy/normal.py
@@ -23,7 +23,7 @@ class NormalEvals(object):
                 Y += list(numpy.imag(path.vertices[:-1]))
                 Z += [epsilon] * (len(path.vertices) - 1)
         contours = pyplot.tricontour(X, Y, Z, levels=epsilons,
-                                     colors=pyplot.rcParams['axes.color_cycle']
+                                    colors=['b', 'g', 'r', 'c', 'm', 'y', 'k']
                                      )
         plot_finish(contours, **kwargs)
         return contours


### PR DESCRIPTION
In recent versions of Matplotlib, axes.color_cycle doesn't exist,
so the plotting routines throw a KeyError.  This fixes that.
I believe the fix is backward-compatible.